### PR TITLE
fix: -webkit-test-size-adjust not supported errors

### DIFF
--- a/css/diaspora.css
+++ b/css/diaspora.css
@@ -1,5 +1,5 @@
 body,div,h1,h2,h3,h4,h5,p,ul,li {margin:0;padding:0;font-weight:normal;list-style:none;}
-html {-webkit-text-size-adjust:100%;}
+html {-webkit-text-size-adjust:100%;text-size-adjust:100%;}
 html,body {-webkit-tap-highlight-color:rgba(0,0,0,0);-webkit-font-smoothing:antialiased;background:#fff;}
 body {font-family:'PingFang SC','Hiragino Sans GB','Microsoft Yahei','WenQuanYi Micro Hei',sans-serif;font-size:14px;position:relative;overflow-x:hidden;}
 body:before {background:grey;position:absolute;content:'';display:block;width:14px;height:14px;left:50%;top:50%;margin-left:-7px;margin-top:-7px;border-radius:50%;-webkit-border-radius:50%;-moz-border-radius:50%;-webkit-animation:loading 2s ease-out forwards infinite;-moz-animation:loading 2s ease-out forwards infinite;display:none;}

--- a/photoswipe/photoswipe.css
+++ b/photoswipe/photoswipe.css
@@ -15,6 +15,7 @@
   touch-action: none;
   z-index: 1500;
   -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
   /* create separate layer, to avoid paint on window.onscroll in webkit/blink */
   -webkit-backface-visibility: hidden;
   outline: none; }


### PR DESCRIPTION
CSS中的 `-webkit-test-size-adjust` 目前在Chrome、Edge（79版之后）、FireFox、Safari上不受支持
参考：[Supported CSS Features](https://webhint.io/docs/user-guide/hints/hint-compat-api/css/)